### PR TITLE
Fix for umbrella apps

### DIFF
--- a/lib/ex_zample/application.ex
+++ b/lib/ex_zample/application.ex
@@ -20,8 +20,8 @@ defmodule ExZample.Application do
 
   def load_manifest do
     files =
-      Mix.Project.manifest_path()
-      |> Path.join("**/*.ex_zample_manifest.elixir")
+      Mix.Project.build_path()
+      |> Path.join("/ex_zample/manifest/**/*.ex_zample_manifest.elixir")
       |> Path.wildcard()
 
     Enum.each(files, fn file ->

--- a/lib/ex_zample/dsl.ex
+++ b/lib/ex_zample/dsl.ex
@@ -150,7 +150,7 @@ defmodule ExZample.DSL do
       end)
 
     file_name = Macro.underscore(caller.module) <> ".ex_zample_manifest.elixir"
-    file = Path.join(Mix.Project.manifest_path(), file_name)
+    file = Path.join([Mix.Project.build_path(), "/ex_zample/manifest/", file_name])
 
     Manifest.write!(file, factories)
   end


### PR DESCRIPTION
Since this lib has been using manifest_path for storing factories, it wasn't working well for umbrella apps because it couldn't proper load the generated manifest from apps inside umbrella.

A easier fix for it is using `Mix.Project.build_path` instead.