### PR TITLE
Fix compile time error message

### DIFF
--- a/lib/ex_zample/dsl/factory.ex
+++ b/lib/ex_zample/dsl/factory.ex
@@ -44,7 +44,7 @@ defmodule ExZample.DSL.Factory do
 
   defp convert_dsl({:example, _context, [[do: block]]}, stats) do
     ast =
-      quote location: :keep do
+      quote do
         @impl ExZample
         def example do
           unquote(block)
@@ -56,7 +56,7 @@ defmodule ExZample.DSL.Factory do
 
   defp convert_dsl({:example, _context, [args, [do: block]]}, stats) do
     ast =
-      quote location: :keep do
+      quote do
         @impl ExZample
         def example(unquote(args)) do
           unquote(block)
@@ -68,7 +68,7 @@ defmodule ExZample.DSL.Factory do
 
   defp convert_dsl({:ecto_repo, _context, [[do: block]]}, stats) do
     ast =
-      quote location: :keep do
+      quote do
         @impl ExZample
         def ecto_repo do
           unquote(block)


### PR DESCRIPTION
Fixes https://github.com/ulissesalmeida/ex_zample/issues/3

After this commit the compile time error will show the file path where the compile error happened instead of the ExZample file path where the code is being called.

### Example

```
== Compilation error in file test/support/factories/game_factory.ex ==
** (CompileError) test/support/factories/game_factory.ex:10: New.__struct__/1
is undefined, cannot expand struct New. Make sure the struct name is correct.
If the struct name exists and is correct but it still cannot be found, you
likely have cyclic module usage in your code
    test/support/factories/game_factory.ex:1: (module)
```

In the error above, this file path: `test/support/factories/game_factory.ex:10` is exactly where this error is coming from.

### Solution

It seems that only removing the `location: :keep` solves this issue.