### PR TITLE
Fix manifest removal of files with only sequences defined

### DIFF
--- a/lib/ex_zample/manifest.ex
+++ b/lib/ex_zample/manifest.ex
@@ -97,10 +97,12 @@ defmodule ExZample.Manifest do
 
   @doc false
   def persist!(file, manifest) do
-    if manifest.aliases == %{} do
+    if empty_manifest?(manifest) do
       File.rm(file)
     else
       write_manifest!(file, manifest)
     end
   end
+
+  defp empty_manifest?(manifest), do: manifest == %{aliases: %{}, sequences: %{}}
 end

--- a/test/ex_zample/dsl_test.exs
+++ b/test/ex_zample/dsl_test.exs
@@ -111,6 +111,10 @@ defmodule ExZample.DSLTest do
       assert 1 == sequence(:user_id)
     end
 
+    test "files only with sequences are loaded" do
+      assert 1 == sequence(:only_sequences_file)
+    end
+
     @tag ex_zample_scope: :ex_zample
     test "generates scoped sequences" do
       assert "ex_zample_user_1" == sequence(:user_id)

--- a/test/support/only_sequences.ex
+++ b/test/support/only_sequences.ex
@@ -1,0 +1,7 @@
+defmodule ExZample.OnlySequences do
+  @moduledoc false
+
+  use ExZample.DSL
+
+  def_sequence :only_sequences_file
+end


### PR DESCRIPTION
Fix a issue for files that has only sequences. Their manifest were being removed so their alias were not found.